### PR TITLE
[feature] test validator pass through args

### DIFF
--- a/.changeset/perfect-penguins-visit.md
+++ b/.changeset/perfect-penguins-visit.md
@@ -1,0 +1,5 @@
+---
+"mucho": minor
+---
+
+add support for pass through args on the test validator command

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is the `mucho`, a command-line tool designed to simplify the development
 and testing of Solana blockchain programs. The tool provides an array of
 commands to manage Solana Toolkit installations, clone and manage blockchain
 fixtures (accounts, programs, etc), and simplifying the experience of running a
-local test-validator with all the required state for a consistent development
+local test validator with all the required state for a consistent development
 experience.
 
 **System Requirements:**
@@ -128,13 +128,13 @@ The default behavior for deploying is as follows:
 
 ### validator
 
-Run the Solana test-validator on your local machine, including loading all the
+Run the Solana test validator on your local machine, including loading all the
 cloned fixtures for your repo.
 
 **Usage:**
 
 ```shell
-npx mucho test-validator --help
+npx mucho validator --help
 ```
 
 > Under the hood, the `validator` commands wraps the Agave tool suite's
@@ -197,7 +197,7 @@ Declare general defaults and configuration settings for use in various places.
   - Default: `fixtures`
 - `keypair` - Path to the default local keypair file to use in various places
   (i.e. set as the upgrade authority for all cloned programs when running
-  `test-validator`)
+  `mucho validator`)
   - Type: `string`
   - Default: `~/.config/solana/id.json` (same as the Agave CLI tool suite)
 
@@ -228,7 +228,7 @@ counter = "BmDHboaj1kBUoinJKKSRqKfMeRKJqQqEbUj1VgzeQe4A"
 counter = "AgVqLc7bKvnLL6TQnBMsMAkT18LixiW9isEb21q1HWUR"
 ```
 
-These addresses will be used to load programs using the `test-validator` at
+These addresses will be used to load programs using the `mucho validator` at
 genesis.
 
 ### `clone` configuration
@@ -348,7 +348,7 @@ this tool supports include:
 - Clone cache - Cloned fixtures are cached by default (in the repo), helping to
   reduce the load on RPC providers. This also helps developers working on the
   same source repository to have a consistent ledger state when performing local
-  development and testing via [`test-validator`](#test-validator).
+  development and testing via [`mucho validator`](#validator).
 - Mix-and-match cloning - This tool allows more
   [fine grain control](#cloneaccount) over which cluster any specific
   account/program gets cloned from. For example, if you want `account1` to come

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -280,8 +280,6 @@ export function deployCommand() {
        * do you want to continue?
        */
 
-      console.log(""); // spacer in the terminal
-
       shellExecInSession({
         command,
         args: passThroughArgs,

--- a/src/commands/validator.ts
+++ b/src/commands/validator.ts
@@ -1,17 +1,14 @@
 import { Command, Option } from "@commander-js/extra-typings";
 import { cliOutputConfig, loadConfigToml } from "@/lib/cli";
 import { titleMessage, warnMessage } from "@/lib/logs";
-import { checkCommand } from "@/lib/shell";
+import { checkCommand, shellExecInSession } from "@/lib/shell";
 import {
   deepMerge,
   doesFileExist,
   loadFileNamesToMap,
   updateGitignore,
 } from "@/lib/utils";
-import {
-  buildTestValidatorCommand,
-  runTestValidator,
-} from "@/lib/shell/test-validator";
+import { buildTestValidatorCommand } from "@/lib/shell/test-validator";
 import { COMMON_OPTIONS } from "@/const/commands";
 import { loadKeypairFromFile } from "@/lib/solana";
 import { DEFAULT_CACHE_DIR, DEFAULT_TEST_LEDGER_DIR } from "@/const/solana";
@@ -51,7 +48,7 @@ export function validatorCommand() {
       .addOption(COMMON_OPTIONS.config)
       .addOption(COMMON_OPTIONS.keypair)
       .addOption(COMMON_OPTIONS.url)
-      .action(async (options) => {
+      .action(async (options, { args: passThroughArgs }) => {
         if (!options.outputOnly) {
           titleMessage("solana-test-validator");
         } else options.output = options.outputOnly;
@@ -167,8 +164,10 @@ export function validatorCommand() {
         );
         console.log(explorerUrl.toString());
 
-        runTestValidator({
+        shellExecInSession({
           command,
+          args: passThroughArgs,
+          outputOnly: options.outputOnly,
         });
       })
   );

--- a/src/commands/validator.ts
+++ b/src/commands/validator.ts
@@ -31,6 +31,13 @@ export function validatorCommand() {
       // .addOption(
       //   new Option("--prompt", "prompt to override any existing cloned accounts"),
       // )
+      .usage("[options] [-- <TEST_VALIDATOR_ARGS>...]")
+      .addOption(
+        new Option(
+          "-- <TEST_VALIDATOR_ARGS>",
+          `arguments to pass to the underlying 'solana-test-validator' command`,
+        ),
+      )
       .addOption(
         new Option(
           "--reset",

--- a/src/lib/prompts/build.ts
+++ b/src/lib/prompts/build.ts
@@ -51,8 +51,8 @@ export async function promptToSelectCluster(
     .catch(() => {
       /**
        * it seems that if we execute the run clone command within another command
-       * (like nesting it under test-validator and prompting the user)
-       * the user may not be able to exit the test-validator process via Ctrl+c
+       * (like nesting it under `mucho validator` and prompting the user)
+       * the user may not be able to exit the `mucho validator` process via Ctrl+c
        * todo: investigate this more to see if we can still allow the command to continue
        */
       // do nothing on user cancel instead of exiting the cli

--- a/src/lib/prompts/clone.ts
+++ b/src/lib/prompts/clone.ts
@@ -31,8 +31,8 @@ export async function promptToAutoClone(): Promise<void | boolean> {
     .catch(() => {
       /**
        * it seems that if we execute the run clone command within another command
-       * (like nesting it under test-validator and prompting the user)
-       * the user may not be able to exit the test-validator process via Ctrl+c
+       * (like nesting it under `mucho validator` and prompting the user)
+       * the user may not be able to exit the `mucho validator` process via Ctrl+c
        * todo: investigate this more to see if we can still allow the command to continue
        */
       // do nothing on user cancel instead of exiting the cli

--- a/src/lib/prompts/install.ts
+++ b/src/lib/prompts/install.ts
@@ -27,7 +27,7 @@ export async function promptToInstall(
     .catch(() => {
       /**
        * it seems that if we execute a Commander command within another command
-       * (like nesting it under test-validator and prompting the user)
+       * (like nesting it under `mucho validator` and prompting the user)
        * the user may not be able to exit the parent command's process via CTRL+C
        * todo: investigate this more to see if we can still allow the command to continue
        */

--- a/src/lib/shell/index.ts
+++ b/src/lib/shell/index.ts
@@ -163,6 +163,8 @@ export function shellExecInSession({
   args = undefined,
   outputOnly,
 }: ShellExecInSessionArgs): ChildProcess | void {
+  console.log(""); // spacer in the terminal
+
   if (outputOnly) {
     args = args || [];
     args.unshift(command);

--- a/src/lib/shell/test-validator.ts
+++ b/src/lib/shell/test-validator.ts
@@ -1,4 +1,3 @@
-import { spawn } from "child_process";
 import { resolve } from "path";
 import { rmSync } from "fs";
 import {
@@ -111,34 +110,4 @@ export function buildTestValidatorCommand({
   // todo: support cloning programs via `--clone-upgradeable-program`?
 
   return command.join(" ");
-}
-
-type RunTestValidatorInput = {
-  command?: string;
-  args?: string[];
-};
-
-export function runTestValidator({ command, args }: RunTestValidatorInput) {
-  console.log(""); // print a line separator
-
-  // Spawn a child process
-  const child = spawn(command, args, {
-    detached: false, // run the command in the same session
-    stdio: "inherit", // Stream directly to the user's terminal
-    shell: true, // Runs in shell for compatibility with shell commands
-    // cwd: // todo: do we want this?
-  });
-
-  // Handle child process events
-  child.on("error", (err) => {
-    console.error(`Failed to start the command: ${err.message}`);
-  });
-
-  child.on("exit", (code) => {
-    if (code === 0) {
-      console.log("Command executed successfully.");
-    } else {
-      console.error(`Command exited with code ${code}`);
-    }
-  });
 }


### PR DESCRIPTION
#### Problem

the `mucho validator` command does not accept pass through args to the underlying test validator command

#### Summary of Changes

add support for the pass through args to the test validator command