### PR TITLE
all test validator args

### DIFF
--- a/.changeset/tidy-dingos-greet.md
+++ b/.changeset/tidy-dingos-greet.md
@@ -1,0 +1,5 @@
+---
+"mucho": patch
+---
+
+refactor using all test validator args and options

--- a/src/commands/validator.ts
+++ b/src/commands/validator.ts
@@ -22,7 +22,6 @@ import { promptToAutoClone } from "@/lib/prompts/clone";
 import { listLocalPrograms } from "@/lib/programs";
 import { cloneCommand } from "@/commands/clone";
 import { getAppInfo } from "@/lib/app-info";
-import { execSync } from "child_process";
 
 /**
  * Command: `validator`
@@ -44,165 +43,158 @@ export function validatorCommand() {
     process.exit();
   }
 
-  return (
-    new Command("validator")
-      .configureOutput(cliOutputConfig)
-      .description("run the Solana test validator on your local machine")
-      // .addOption(
-      //   new Option("--prompt", "prompt to override any existing cloned accounts"),
-      // )
-      .usage("[options] [-- <TEST_VALIDATOR_ARGS>...]")
-      .addOption(
-        new Option(
-          "-- <TEST_VALIDATOR_ARGS>",
-          `arguments to pass to the underlying 'solana-test-validator' command`,
-        ),
-      )
-      .addOption(
-        new Option(
-          "--reset",
-          "reset the test validator to genesis, reloading all preloaded fixtures",
-        ),
-      )
-      .addOption(
-        new Option(
-          "-l, --ledger <LEDGER_DIR>",
-          "location for the local ledger",
-        ).default(DEFAULT_TEST_LEDGER_DIR),
-      )
-      .addOption(
-        new Option(
-          "--output",
-          "output the generated test validator command while executing it",
-        ),
-      )
-      .addOption(COMMON_OPTIONS.outputOnly)
-      .addOption(COMMON_OPTIONS.accountDir)
-      .addOption(COMMON_OPTIONS.config)
-      .addOption(COMMON_OPTIONS.keypair)
-      .addOption(COMMON_OPTIONS.url)
-      .action(async (options, { args: passThroughArgs }) => {
-        if (!options.outputOnly) {
-          titleMessage("solana-test-validator");
-        } else options.output = options.outputOnly;
+  return new Command("validator")
+    .allowUnknownOption(true)
+    .addHelpText(
+      "afterAll",
+      "Additional Options:\n" + "  see 'solana-test-validator --help'",
+    )
+    .configureOutput(cliOutputConfig)
+    .description("run the Solana test validator on your local machine")
+    .addOption(
+      new Option(
+        "--reset",
+        "reset the test validator to genesis, reloading all preloaded fixtures",
+      ),
+    )
+    .addOption(
+      new Option(
+        "-l, --ledger <LEDGER_DIR>",
+        "location for the local ledger",
+      ).default(DEFAULT_TEST_LEDGER_DIR),
+    )
+    .addOption(
+      new Option(
+        "--output",
+        "output the generated test validator command while executing it",
+      ),
+    )
+    .addOption(COMMON_OPTIONS.outputOnly)
+    .addOption(COMMON_OPTIONS.accountDir)
+    .addOption(COMMON_OPTIONS.config)
+    .addOption(COMMON_OPTIONS.keypair)
+    .addOption(COMMON_OPTIONS.url)
+    .action(async (options, { args: passThroughArgs }) => {
+      if (!options.outputOnly) {
+        titleMessage("solana-test-validator");
+      } else options.output = options.outputOnly;
 
-        await checkCommand("solana-test-validator --version", {
-          exit: true,
-          message:
-            "Unable to detect the 'solana-test-validator'. Do you have it installed?",
-        });
+      await checkCommand("solana-test-validator --version", {
+        exit: true,
+        message:
+          "Unable to detect the 'solana-test-validator'. Do you have it installed?",
+      });
 
-        let config = loadConfigToml(options.config, options);
+      let config = loadConfigToml(options.config, options);
 
-        updateGitignore([DEFAULT_CACHE_DIR, DEFAULT_TEST_LEDGER_DIR]);
+      updateGitignore([DEFAULT_CACHE_DIR, DEFAULT_TEST_LEDGER_DIR]);
 
-        let authorityAddress: string | null = null;
-        if (config.settings.keypair) {
-          if (doesFileExist(config.settings.keypair)) {
-            authorityAddress = loadKeypairFromFile(
-              config.settings.keypair,
-            )?.publicKey.toBase58();
-          } else {
-            warnMessage(
-              `Unable to locate keypair file: ${config.settings.keypair}`,
-            );
-            warnMessage("Skipping auto creation and setting authorities");
-          }
-        }
-
-        // let localPrograms: SolanaTomlCloneLocalProgram = {};
-        let locatedPrograms: ReturnType<
-          typeof listLocalPrograms
-        >["locatedPrograms"] = {};
-
-        // attempt to load and combine the anchor toml clone settings
-        const anchorToml = loadAnchorToml(config.configPath);
-        if (anchorToml) {
-          config = deconflictAnchorTomlWithConfig(anchorToml, config);
-
-          // deep merge the solana and anchor config, taking priority with solana toml
-          config.programs = deepMerge(config.programs, anchorToml.programs);
-        }
-
-        Object.assign(
-          locatedPrograms,
-          listLocalPrograms({
-            configPath: config.configPath,
-            labels: config.programs,
-            cluster: "localnet", // todo: handle the user selecting the `cluster`
-          }).locatedPrograms,
-        );
-
-        // todo: check if all the local programs were compiled/found, if not => prompt
-        // if (!localListing.allFound) {
-        //   // todo: add the ability to prompt the user to build their anchor programs
-        //   warnMessage(`Have you built all your local programs?`);
-        // }
-
-        // auto run the clone on reset
-        if (options.reset) {
-          // run the clone command with default options
-          // todo: could we pass options in here if we want?
-          await cloneCommand().parseAsync([]);
-        }
-
-        // todo: this is flaky and does not seem to detect if some are missing. fix it
-        const cloneCounts = validateExpectedCloneCounts(
-          config.settings.accountDir,
-          config.clone,
-        );
-        if (cloneCounts.actual !== cloneCounts.expected) {
+      let authorityAddress: string | null = null;
+      if (config.settings.keypair) {
+        if (doesFileExist(config.settings.keypair)) {
+          authorityAddress = loadKeypairFromFile(
+            config.settings.keypair,
+          )?.publicKey.toBase58();
+        } else {
           warnMessage(
-            `Expected ${cloneCounts.expected} fixtures, but only ${cloneCounts.actual} found.`,
+            `Unable to locate keypair file: ${config.settings.keypair}`,
           );
-
-          if (!options.outputOnly) {
-            await promptToAutoClone();
-          }
+          warnMessage("Skipping auto creation and setting authorities");
         }
+      }
 
-        const command = buildTestValidatorCommand({
-          verbose: !options.output,
-          reset: options.reset || false,
-          accountDir: config.settings.accountDir,
-          ledgerDir: config.settings.ledgerDir,
-          // todo: allow setting the authority from the cli args
-          authority: authorityAddress,
-          localPrograms: locatedPrograms,
-        });
+      // let localPrograms: SolanaTomlCloneLocalProgram = {};
+      let locatedPrograms: ReturnType<
+        typeof listLocalPrograms
+      >["locatedPrograms"] = {};
 
-        if (options.output) console.log(`\n${command}\n`);
-        // only log the "run validator" command, do not execute it
-        if (options.outputOnly) process.exit();
+      // attempt to load and combine the anchor toml clone settings
+      const anchorToml = loadAnchorToml(config.configPath);
+      if (anchorToml) {
+        config = deconflictAnchorTomlWithConfig(anchorToml, config);
 
-        if (options.reset) {
-          console.log(
-            "Loaded",
-            loadFileNamesToMap(config.settings.accountDir, ".json").size,
-            "accounts into the local validator",
-          );
-          console.log(
-            "Loaded",
-            loadFileNamesToMap(config.settings.accountDir, ".so").size,
-            "programs into the local validator",
-          );
-        }
+        // deep merge the solana and anchor config, taking priority with solana toml
+        config.programs = deepMerge(config.programs, anchorToml.programs);
+      }
 
-        const explorerUrl = new URL(
-          "https://explorer.solana.com/?cluster=custom",
+      Object.assign(
+        locatedPrograms,
+        listLocalPrograms({
+          configPath: config.configPath,
+          labels: config.programs,
+          cluster: "localnet", // todo: handle the user selecting the `cluster`
+        }).locatedPrograms,
+      );
+
+      // todo: check if all the local programs were compiled/found, if not => prompt
+      // if (!localListing.allFound) {
+      //   // todo: add the ability to prompt the user to build their anchor programs
+      //   warnMessage(`Have you built all your local programs?`);
+      // }
+
+      // auto run the clone on reset
+      if (options.reset) {
+        // run the clone command with default options
+        // todo: could we pass options in here if we want?
+        await cloneCommand().parseAsync([]);
+      }
+
+      // todo: this is flaky and does not seem to detect if some are missing. fix it
+      const cloneCounts = validateExpectedCloneCounts(
+        config.settings.accountDir,
+        config.clone,
+      );
+      if (cloneCounts.actual !== cloneCounts.expected) {
+        warnMessage(
+          `Expected ${cloneCounts.expected} fixtures, but only ${cloneCounts.actual} found.`,
         );
-        explorerUrl.searchParams.set("customUrl", "http://localhost:8899");
-        console.log("\nSolana Explorer for your local test validator:");
+
+        if (!options.outputOnly) {
+          await promptToAutoClone();
+        }
+      }
+
+      const command = buildTestValidatorCommand({
+        verbose: !options.output,
+        reset: options.reset || false,
+        accountDir: config.settings.accountDir,
+        ledgerDir: config.settings.ledgerDir,
+        // todo: allow setting the authority from the cli args
+        authority: authorityAddress,
+        localPrograms: locatedPrograms,
+      });
+
+      if (options.output) console.log(`\n${command}\n`);
+      // only log the "run validator" command, do not execute it
+      if (options.outputOnly) process.exit();
+
+      if (options.reset) {
         console.log(
-          "(on Brave Browser, you may need to turn Shields down for the Explorer website)",
+          "Loaded",
+          loadFileNamesToMap(config.settings.accountDir, ".json").size,
+          "accounts into the local validator",
         );
-        console.log(explorerUrl.toString());
+        console.log(
+          "Loaded",
+          loadFileNamesToMap(config.settings.accountDir, ".so").size,
+          "programs into the local validator",
+        );
+      }
 
-        shellExecInSession({
-          command,
-          args: passThroughArgs,
-          outputOnly: options.outputOnly,
-        });
-      })
-  );
+      const explorerUrl = new URL(
+        "https://explorer.solana.com/?cluster=custom",
+      );
+      explorerUrl.searchParams.set("customUrl", "http://localhost:8899");
+      console.log("\nSolana Explorer for your local test validator:");
+      console.log(
+        "(on Brave Browser, you may need to turn Shields down for the Explorer website)",
+      );
+      console.log(explorerUrl.toString());
+
+      shellExecInSession({
+        command,
+        args: passThroughArgs,
+        outputOnly: options.outputOnly,
+      });
+    });
 }

--- a/src/commands/validator.ts
+++ b/src/commands/validator.ts
@@ -66,6 +66,12 @@ export function validatorCommand() {
       )
       .addOption(
         new Option(
+          "-l, --ledger <LEDGER_DIR>",
+          "location for the local ledger",
+        ).default(DEFAULT_TEST_LEDGER_DIR),
+      )
+      .addOption(
+        new Option(
           "--output",
           "output the generated test validator command while executing it",
         ),
@@ -159,6 +165,7 @@ export function validatorCommand() {
           verbose: !options.output,
           reset: options.reset || false,
           accountDir: config.settings.accountDir,
+          ledgerDir: config.settings.ledgerDir,
           // todo: allow setting the authority from the cli args
           authority: authorityAddress,
           localPrograms: locatedPrograms,

--- a/src/const/commands.ts
+++ b/src/const/commands.ts
@@ -19,7 +19,7 @@ export const COMMON_OPTIONS = {
    * note: this is a different config file than the solana cli's config file
    */
   config: new Option(
-    "-c --config <PATH>",
+    "-C --config <PATH>",
     "path to a Solana.toml config file",
   ).default(DEFAULT_CONFIG_FILE),
   /**

--- a/src/lib/cli.ts
+++ b/src/lib/cli.ts
@@ -13,7 +13,11 @@ import {
   loadYamlFile,
 } from "@/lib/utils";
 import { SolanaToml, SolanaTomlWithConfigPath } from "@/types/config";
-import { DEFAULT_CLI_YAML_PATH, DEFAULT_CONFIG_FILE } from "@/const/solana";
+import {
+  DEFAULT_CLI_YAML_PATH,
+  DEFAULT_CONFIG_FILE,
+  DEFAULT_TEST_LEDGER_DIR,
+} from "@/const/solana";
 import { COMMON_OPTIONS } from "@/const/commands";
 import { warningOutro, warnMessage } from "@/lib/logs";
 import { SolanaCliYaml } from "@/types/solana";
@@ -89,6 +93,7 @@ export function loadConfigToml(
     cluster: COMMON_OPTIONS.url.defaultValue,
     accountDir: COMMON_OPTIONS.accountDir.defaultValue,
     keypair: COMMON_OPTIONS.keypair.defaultValue,
+    ledgerDir: DEFAULT_TEST_LEDGER_DIR,
   };
 
   config.settings = Object.assign(defaultSettings, config.settings || {});

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -11,6 +11,8 @@ export type SolanaToml = {
      * when not set, fallback to the Solana CLI cluster
      */
     cluster: SolanaCluster;
+    /** local directory for the ledger */
+    ledgerDir?: string;
     /** local directory path to store any cloned accounts */
     accountDir: string;
     /** path to the local authority keypair */


### PR DESCRIPTION
#### Problem

mucho does not easily support all test validator arguments. users have to pass in an extra `--` in order to do so. this is annoying and confusing.

#### Summary of Changes

removed the need for adding in the extra `--` flag and auto pass through all provided args

Fixes #10