### PR TITLE
fix unhandled errors with no cli config yml

### DIFF
--- a/.changeset/wild-suns-breathe.md
+++ b/.changeset/wild-suns-breathe.md
@@ -1,0 +1,6 @@
+---
+"mucho": patch
+---
+
+handle error when no cli config is set. also improve error handling around no
+keypair file existing

--- a/src/const/commands.ts
+++ b/src/const/commands.ts
@@ -26,7 +26,7 @@ export const COMMON_OPTIONS = {
    * path to the local authority keypair
    */
   keypair: new Option("--keypair <PATH>", "path to a keypair file").default(
-    cliConfig.keypair_path || DEFAULT_KEYPAIR_PATH,
+    cliConfig?.keypair_path || DEFAULT_KEYPAIR_PATH,
   ),
   /**
    * rpc url or moniker to use

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,30 +18,35 @@ import { deployCommand } from "@/commands/deploy";
 assertRuntimeVersion();
 
 async function main() {
-  // auto check for new version of the cli
-  await checkForSelfUpdate();
-
+  // create a global error boundary
   try {
-    const program = cliProgramRoot();
+    // auto check for new version of the cli
+    await checkForSelfUpdate();
 
-    program
-      .addCommand(installCommand())
-      // .addCommand(doctorCommand())
-      .addCommand(validatorCommand())
-      .addCommand(cloneCommand())
-      .addCommand(buildCommand())
-      .addCommand(deployCommand())
-      .addCommand(coverageCommand())
-      .addCommand(infoCommand());
+    try {
+      const program = cliProgramRoot();
 
-    // set the default action to `help` without an error
-    if (process.argv.length === 2) {
-      process.argv.push("--help");
+      program
+        .addCommand(installCommand())
+        // .addCommand(doctorCommand())
+        .addCommand(validatorCommand())
+        .addCommand(cloneCommand())
+        .addCommand(buildCommand())
+        .addCommand(deployCommand())
+        .addCommand(coverageCommand())
+        .addCommand(infoCommand());
+
+      // set the default action to `help` without an error
+      if (process.argv.length === 2) {
+        process.argv.push("--help");
+      }
+
+      await program.parseAsync();
+    } catch (err) {
+      errorMessage(err.toString());
     }
-
-    await program.parseAsync();
   } catch (err) {
-    errorMessage(err.toString());
+    errorMessage(err, "[mucho - unhandled error]");
   }
 }
 

--- a/src/lib/cli.ts
+++ b/src/lib/cli.ts
@@ -16,6 +16,7 @@ import { SolanaToml, SolanaTomlWithConfigPath } from "@/types/config";
 import {
   DEFAULT_CLI_YAML_PATH,
   DEFAULT_CONFIG_FILE,
+  DEFAULT_KEYPAIR_PATH,
   DEFAULT_TEST_LEDGER_DIR,
 } from "@/const/solana";
 import { COMMON_OPTIONS } from "@/const/commands";
@@ -25,32 +26,40 @@ import { SolanaCliYaml } from "@/types/solana";
 /**
  * Load the Solana CLI's config file
  */
-export function loadSolanaCliConfig(filePath: string = DEFAULT_CLI_YAML_PATH) {
-  const cliConfig = loadYamlFile<SolanaCliYaml>(filePath);
+export function loadSolanaCliConfig(
+  filePath: string = DEFAULT_CLI_YAML_PATH,
+): SolanaCliYaml {
+  try {
+    const cliConfig = loadYamlFile<SolanaCliYaml>(filePath);
 
-  // auto convert the rpc url to the cluster moniker
-  if (cliConfig?.json_rpc_url) {
-    switch (cliConfig.json_rpc_url) {
-      case "https://api.devnet.solana.com": {
-        cliConfig.json_rpc_url = "devnet";
-        break;
-      }
-      case "https://api.testnet.solana.com": {
-        cliConfig.json_rpc_url = "testnet";
-        break;
-      }
-      case "https://api.mainnet-beta.solana.com": {
-        cliConfig.json_rpc_url = "mainnet";
-        break;
-      }
-      case "http://localhost:8899": {
-        cliConfig.json_rpc_url = "localhost";
-        break;
+    // auto convert the rpc url to the cluster moniker
+    if (cliConfig?.json_rpc_url) {
+      switch (cliConfig.json_rpc_url) {
+        case "https://api.devnet.solana.com": {
+          cliConfig.json_rpc_url = "devnet";
+          break;
+        }
+        case "https://api.testnet.solana.com": {
+          cliConfig.json_rpc_url = "testnet";
+          break;
+        }
+        case "https://api.mainnet-beta.solana.com": {
+          cliConfig.json_rpc_url = "mainnet";
+          break;
+        }
+        case "http://localhost:8899": {
+          cliConfig.json_rpc_url = "localhost";
+          break;
+        }
       }
     }
-  }
 
-  return cliConfig;
+    return cliConfig;
+  } catch (err) {
+    return {
+      keypair_path: DEFAULT_KEYPAIR_PATH,
+    };
+  }
 }
 
 /**

--- a/src/lib/logs.ts
+++ b/src/lib/logs.ts
@@ -2,7 +2,7 @@ import picocolors from "picocolors";
 import type { Formatter } from "picocolors/types";
 
 /**
- * Print a plain message using clack's `outro`
+ * Print a plain message using `picocolors`
  * (including a process exit code)
  */
 export function titleMessage(
@@ -37,7 +37,7 @@ export function warningOutro(msg: string = "Operation canceled") {
 }
 
 /**
- * Print a plain message using clack's `outro`
+ * Print a plain message using `picocolors`
  * (including a process exit code)
  */
 export function cancelOutro(msg: string = "Operation canceled") {
@@ -47,7 +47,7 @@ export function cancelOutro(msg: string = "Operation canceled") {
 }
 
 /**
- * Print a blue notice message using clack's `outro`
+ * Print a blue notice message using `picocolors`
  * (including a process exit code)
  */
 export function noticeOutro(msg: string) {
@@ -57,7 +57,7 @@ export function noticeOutro(msg: string) {
 }
 
 /**
- * Print a green success message using clack's `outro`
+ * Print a green success message using `picocolors`
  * (including a process exit code)
  */
 export function successOutro(msg: string = "Operation successful") {
@@ -67,19 +67,19 @@ export function successOutro(msg: string = "Operation successful") {
 }
 
 /**
- * Print a red error message using clack's `outro`
+ * Print a red error message using `picocolors`
  * (including a process exit code)
  */
 export function errorOutro(msg: string, title: string | null = null) {
   if (title) {
-    console.log(picocolors.bgRed(` ${title} `));
+    console.log(picocolors.bgRed(title));
     console.log(msg, "\n");
   } else console.log(picocolors.bgRed(` ${msg} `), "\n");
   process.exit(1);
 }
 
 /**
- * Display a error message with using clack
+ * Display a error message with using `picocolors`
  * (including a process exit code)
  */
 export function errorMessage(err: any, title: string = "An error occurred") {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -29,11 +29,10 @@ export function loadPlaintextFile(filePath: string): string | null {
     return data;
   } catch (error) {
     if (error.code === "ENOENT") {
-      console.error("File not found:", filePath);
+      throw new Error(`File not found: ${filePath}`);
     } else {
-      console.error("Error reading file:", error.message);
+      throw new Error(`Error reading file: ${error.message}`);
     }
-    return null;
   }
 }
 


### PR DESCRIPTION
#### Problem

when no cli config.yml file exists (aka the user has not installed the solana cli or has never changed their settings), an unhandled error will be shown to the user

#### Summary of Changes

- added a global error boundary
- improved error throwing (instead of `console.warn`)
- improved the `info` messages when no cli config yml or local keypair is found

Fixes #14