### PR TITLE
Fix self installing

### DIFF
--- a/.changeset/long-meals-remain.md
+++ b/.changeset/long-meals-remain.md
@@ -1,0 +1,6 @@
+---
+"mucho": patch
+---
+
+fix self installer to correctly detect installed mucho version. also to always
+install the latest version

--- a/README.md
+++ b/README.md
@@ -85,11 +85,11 @@ mucho clone --help
 
 The default behavior for fixture cloning is as follows:
 
-- All cloned fixtures are stored in the `fixtures` directory, unless overriden
+- All cloned fixtures are stored in the `fixtures` directory, unless overridden
   by your Solana.toml's `settings.accountDir`.
 - All fixtures are cloned from Solana's mainnet cluster or the declared
   `settings.cluster` in Solana.toml.
-- All fixtures are cloned from the same cluster, unless individually overriden.
+- All fixtures are cloned from the same cluster, unless individually overridden.
 - If any fixtures already exist, they are skipped from cloning.
 - If a Solana account is cloned, the `owner` program will automatically be
   cloned from the same cluster, unless the program is explicitly declared in the
@@ -135,7 +135,7 @@ mucho deploy --help
 The default behavior for deploying is as follows:
 
 - The `deploy` command will default to your Solana CLI declared cluster, unless
-  overriden with the `-u, --url` flag.
+  overridden with the `-u, --url` flag.
 
 ### validator
 
@@ -209,7 +209,7 @@ You can find an [example Solana.toml file](./tests/Solana.toml) here.
 Declare general defaults and configuration settings for use in various places.
 
 - `cluster` - Desired cluster to clone all fixtures from (if not individually
-  overriden per fixture). If not defined, defaults to Solana's mainnet.
+  overridden per fixture). If not defined, defaults to Solana's mainnet.
   - Type: `enum`
   - Default: `mainnet`
   - Values: `mainnet`, `devnet`, or `testnet`

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -17,7 +17,6 @@ import {
 import { checkShellPathSource } from "@/lib/setup";
 import { PathSourceStatus, TOOL_CONFIG } from "@/const/setup";
 import { getCargoUpdateOutput, getNpmPackageUpdates } from "@/lib/update";
-import { getNpmRegistryPackageVersion } from "@/lib/npm";
 
 const toolNames: Array<ToolNames> = [
   "mucho",
@@ -75,17 +74,16 @@ export function installCommand() {
         // track which commands may require a path/session refresh
         const pathsToRefresh: string[] = [];
 
-        const updatesAvailable = await getNpmPackageUpdates("mucho");
+        const updatesAvailable = await getNpmPackageUpdates("mucho", true);
 
-        if (!toolName || toolName == "mucho") {
-          await installMucho({
-            os,
-            version,
-            updateAvailable: updatesAvailable.filter(
-              (data) => data.name.toLowerCase() == "mucho",
-            )[0],
-          });
-        }
+        // always check and install `mucho`
+        await installMucho({
+          os,
+          version,
+          updateAvailable: updatesAvailable.filter(
+            (data) => data.name.toLowerCase() == "mucho",
+          )[0],
+        });
 
         if (!toolName || toolName == "rust") {
           await installRust({

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -19,7 +19,6 @@ import { PathSourceStatus, TOOL_CONFIG } from "@/const/setup";
 import { getCargoUpdateOutput, getNpmPackageUpdates } from "@/lib/update";
 
 const toolNames: Array<ToolNames> = [
-  "mucho",
   "rust",
   "solana",
   "avm",

--- a/src/const/setup.ts
+++ b/src/const/setup.ts
@@ -21,9 +21,6 @@ export const TOOL_CONFIG: { [key in ToolNames]: ToolCommandConfig } = {
   yarn: {
     version: "yarn --version",
   },
-  mucho: {
-    version: "mucho --version",
-  },
   trident: {
     dependencies: ["rust"],
     // the trident cli does not have a version command, so we grab it from cargo

--- a/src/lib/install.ts
+++ b/src/lib/install.ts
@@ -13,6 +13,7 @@ import shellExec from "shell-exec";
 import ora from "ora";
 import { TOOL_CONFIG } from "@/const/setup";
 import picocolors from "picocolors";
+import { getCurrentNpmPackageVersion } from "./npm";
 
 /**
  * Install the mucho cli
@@ -25,21 +26,18 @@ export async function installMucho({
   try {
     let installedVersion = await installedToolVersion("mucho");
     if (installedVersion) {
-      let message = `mucho ${installedVersion} is already installed`;
-      if (updateAvailable) {
-        message = picocolors.yellow(
-          message + ` - v${updateAvailable.latest} available`,
-        );
+      if (!updateAvailable) {
+        spinner.info(`mucho ${installedVersion} is already installed`);
+        return true;
       }
-      spinner.info(message);
-      return true;
-    }
+      spinner.text = `Updating the mucho cli`;
+    } else spinner.text = `Installing the mucho cli`;
 
-    spinner.text = `Installing the mucho cli`;
-    await shellExec(`npm install -gy mucho@latest`);
+    await shellExec(`npm install -gy --force mucho@latest`);
 
     spinner.text = "Verifying mucho was installed";
-    installedVersion = await installedToolVersion("mucho");
+    installedVersion = await getCurrentNpmPackageVersion("mucho", true);
+
     if (installedVersion) {
       spinner.succeed(`mucho ${installedVersion} installed`);
       return installedVersion;

--- a/src/lib/install.ts
+++ b/src/lib/install.ts
@@ -22,9 +22,9 @@ import { getCurrentNpmPackageVersion } from "./npm";
 export async function installMucho({
   updateAvailable,
 }: InstallCommandPropsBase = {}) {
-  const spinner = ora("Installing the mucho cli...").start();
+  const spinner = ora("Checking the mucho cli...").start();
   try {
-    let installedVersion = await installedToolVersion("mucho");
+    let installedVersion = await getCurrentNpmPackageVersion("mucho", true);
     if (installedVersion) {
       if (!updateAvailable) {
         spinner.info(`mucho ${installedVersion} is already installed`);

--- a/src/lib/setup.ts
+++ b/src/lib/setup.ts
@@ -27,7 +27,6 @@ export async function checkInstalledTools({
     yarn: false,
     trident: false,
     zest: false,
-    mucho: false,
     "cargo-update": false,
     verify: false,
   };

--- a/src/lib/update.ts
+++ b/src/lib/update.ts
@@ -28,7 +28,7 @@ export async function getNpmPackageUpdates(
     (registry.latest && isVersionNewer(registry.latest, current))
   ) {
     updates.push({
-      installed: current || "none",
+      installed: current,
       needsUpdate: true,
       latest: registry.latest,
       name: packageName,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -58,7 +58,7 @@ export type ShellExecInSessionArgs = {
 
 export type PackageUpdate = {
   name: string;
-  installed: string;
+  installed: string | false;
   latest: string;
   needsUpdate: boolean;
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,7 +6,6 @@ export type ToolNames =
   | "avm"
   | "anchor"
   | "yarn"
-  | "mucho"
   | "zest"
   | "cargo-update"
   | "verify"


### PR DESCRIPTION
#### Problem

the self installer is flaky and does not properly detect what version the user actually has installed (if any)

#### Summary of Changes

- `mucho install` will always install the latest version of mucho globally
- detect the mucho version via `npm list` vice `mucho --version`
- fixed some typos in the readme