### PR TITLE
Fix anchor version changing

### DIFF
--- a/.changeset/real-doors-lick.md
+++ b/.changeset/real-doors-lick.md
@@ -1,0 +1,5 @@
+---
+"mucho": patch
+---
+
+fix `install` command force changing anchor version to match avm version

--- a/src/lib/install.ts
+++ b/src/lib/install.ts
@@ -300,25 +300,35 @@ export async function installAnchorVersionManager({
 export async function installAnchorUsingAvm({
   verifyParentCommand = true,
   version = "latest",
+  updateAvailable,
 }: InstallCommandPropsBase = {}) {
   const spinner = ora("Installing anchor using avm...").start();
   try {
     let installedVersion = await installedToolVersion("anchor");
-    if (installedVersion && installedVersion == version) {
-      spinner.info(`anchor ${installedVersion} is already installed`);
+
+    if (installedVersion) {
+      let message = `anchor ${installedVersion} is already installed`;
+      if (updateAvailable) {
+        message = picocolors.yellow(
+          message + ` - v${updateAvailable.latest} available`,
+        );
+      }
+      spinner.info(message);
       return true;
     }
 
-    spinner.text = `Verifying avm is installed`;
-    const avmVersion = await installedToolVersion("avm");
+    if (verifyParentCommand) {
+      spinner.text = `Verifying avm is installed`;
+      const avmVersion = await installedToolVersion("avm");
 
-    if (!avmVersion) {
-      // todo: smart install avm?
-      throw `avm is NOT already installed`;
-      // todo: better error response handling
-    } else {
-      // todo: support other versions of anchor via avm
-      version = avmVersion;
+      if (!avmVersion) {
+        // todo: smart install avm?
+        throw `avm is NOT already installed`;
+        // todo: better error response handling
+      } else {
+        // todo: support other versions of anchor via avm
+        version = avmVersion;
+      }
     }
 
     // note: intentionally recheck the version due to avm allowing tags like `stable`

--- a/src/types/anchor.ts
+++ b/src/types/anchor.ts
@@ -18,3 +18,10 @@ export type AnchorToml = {
 
 export type AnchorTomlWithConfigPath = Omit<AnchorToml, "configPath"> &
   NonNullable<{ configPath: AnchorToml["configPath"] }>;
+
+export type AnchorVersionData = {
+  current: null | string;
+  latest: null | string;
+  installed: string[];
+  available: string[];
+};


### PR DESCRIPTION
#### Problem

the `install` command will always set the user's current anchor version to match the installed avm version. resulting in mucho force changing their selected anchor version (potentially unwanted), including force downgrading the anchor version if their avm version is very old

#### Summary of Changes

- added code to get all available anchor version (via `avm`)
- check the current vs latest version of anchor

Fixes #31