### PR TITLE
fix: no-warnings

### DIFF
--- a/.changeset/tiny-plums-tap.md
+++ b/.changeset/tiny-plums-tap.md
@@ -1,0 +1,5 @@
+---
+"mucho": patch
+---
+
+fix no warning breakage

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node --no-warnings
+#!/usr/bin/env node
 
 import { assertRuntimeVersion } from "@/lib/node";
 import { checkForSelfUpdate } from "@/lib/npm";


### PR DESCRIPTION
#### Problem

- the `--no-warnings` flag does not work when mucho is installed, but does when running from the repo

Fixes #