### PR TITLE
[installer] ensure rustup is installed

### DIFF
--- a/.changeset/twenty-months-type.md
+++ b/.changeset/twenty-months-type.md
@@ -1,0 +1,5 @@
+---
+"mucho": patch
+---
+
+ensure the installer checks for rustup AND rustc

--- a/src/const/setup.ts
+++ b/src/const/setup.ts
@@ -8,6 +8,9 @@ export const TOOL_CONFIG: { [key in ToolNames]: ToolCommandConfig } = {
     pathSource: "$HOME/.cargo/env",
     version: "rustc --version",
   },
+  rustup: {
+    version: "rustup --version",
+  },
   solana: {
     dependencies: ["rust"],
     pathSource: "$HOME/.local/share/solana/install/active_release/bin",

--- a/src/lib/install.ts
+++ b/src/lib/install.ts
@@ -140,11 +140,18 @@ export async function installRust({ version }: InstallCommandPropsBase = {}) {
       }
     }
 
-    let installedVersion = await installedToolVersion("rust");
-    if (installedVersion) {
-      spinner.info(`rust ${installedVersion} is already installed`);
-      // todo: detect if the $PATH is actually loaded
-      return true;
+    let [installedVersion, rustupVersion] = await Promise.all([
+      installedToolVersion("rust"),
+      installedToolVersion("rustup"),
+    ]);
+
+    if (rustupVersion) {
+      installedVersion = await installedToolVersion("rust");
+      if (installedVersion) {
+        spinner.info(`rust ${installedVersion} is already installed`);
+        // todo: detect if the $PATH is actually loaded
+        return true;
+      }
     }
 
     spinner.text = "Installing the rust toolchain using rustup";

--- a/src/lib/setup.ts
+++ b/src/lib/setup.ts
@@ -20,6 +20,7 @@ export async function checkInstalledTools({
   let allInstalled = true;
 
   let status: { [key in ToolNames]: string | boolean } = {
+    rustup: false,
     rust: false,
     solana: false,
     avm: false,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,6 +2,7 @@ export type PlatformOS = "unknown" | "linux" | "mac" | "windows";
 
 export type ToolNames =
   | "rust"
+  | "rustup"
   | "solana"
   | "avm"
   | "anchor"


### PR DESCRIPTION
#### Problem

the current rust installer code only checks for `rustc` being installed but not `rustup` as well. rustup is required by solana platform tools to link the `solana` toolchain ([see here](https://github.com/anza-xyz/agave/blob/f5d6ebcfbf8bbf9f88dca5441cfd2c9fb1e8f703/platform-tools-sdk/sbf/scripts/install.sh#L133))

#### Summary of Changes

explicitly ensure rustup is installed, and if not install it

Related issue: https://github.com/solana-developers/mucho/issues/42