### PR TITLE
feat: installer script

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,17 +11,36 @@ experience.
 > [open issues](https://github.com/solana-developers/mucho/issues) with any
 > feedback, feature requests, or issues you experience.
 
+## Installation
+
 **System Requirements:**
 
 - NodeJS (version >= 22)
 
-**Installation:**
+### Install with NodeJS already installed
+
+With NodeJS already installed on your system:
 
 ```shell
 npm install -gy mucho@latest
 ```
 
-**Usage:**
+Or to install mucho and all the core Solana development tooling at once:
+
+```shell
+npx mucho@latest install
+```
+
+### Install without NodeJS already installed
+
+The following command will install NodeJS, Node Version Manager
+([NVM](https://github.com/nvm-sh/nvm)), and `mucho` itself:
+
+```shell
+curl -sSfL https://raw.githubusercontent.com/solana-developers/mucho/master/install.sh | bash
+```
+
+## Usage
 
 ```shell
 mucho --help

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+########################################
+# Logging Functions
+########################################
+log_info() {
+    printf "[INFO] %s\n" "$1"
+}
+
+log_error() {
+    printf "[ERROR] %s\n" "$1" >&2
+}
+
+########################################
+# Install nvm and Node.js
+########################################
+install_nvm_and_node() {
+    if [ -s "$HOME/.nvm/nvm.sh" ]; then
+        log_info "NVM is already installed."
+    else
+        log_info "Installing NVM..."
+        curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/master/install.sh | bash
+    fi
+
+    export NVM_DIR="$HOME/.nvm"
+    # Immediately source nvm and bash_completion for the current session
+    if [ -s "$NVM_DIR/nvm.sh" ]; then
+        . "$NVM_DIR/nvm.sh"
+    else
+        log_error "nvm not found. Ensure it is installed correctly."
+    fi
+
+    if [ -s "$NVM_DIR/bash_completion" ]; then
+        . "$NVM_DIR/bash_completion"
+    fi
+
+    if command -v node >/dev/null 2>&1; then
+        local current_node
+        current_node=$(node --version)
+        local latest_node
+        latest_node=$(nvm version-remote node)
+        if [ "$current_node" = "$latest_node" ]; then
+            log_info "Latest Node.js ($current_node) is already installed."
+        else
+            log_info "Updating Node.js: Installed ($current_node), Latest ($latest_node)."
+            nvm install node
+            nvm alias default node
+            nvm use default
+        fi
+    else
+        log_info "Installing Node.js via NVM..."
+        nvm install node
+        nvm alias default node
+        nvm use default
+    fi
+
+    echo ""
+}
+
+
+########################################
+# Append nvm Initialization to the Correct Shell RC File
+########################################
+ensure_nvm_in_shell() {
+    local shell_rc=""
+    if [[ "$SHELL" == *"zsh"* ]]; then
+        shell_rc="$HOME/.zshrc"
+    elif [[ "$SHELL" == *"bash"* ]]; then
+        shell_rc="$HOME/.bashrc"
+    else
+        shell_rc="$HOME/.profile"
+    fi
+
+    if [ -f "$shell_rc" ]; then
+        if ! grep -q 'export NVM_DIR="$HOME/.nvm"' "$shell_rc"; then
+            log_info "Appending nvm initialization to $shell_rc"
+            {
+                echo ''
+                echo 'export NVM_DIR="$HOME/.nvm"'
+                echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm'
+            } >> "$shell_rc"
+        fi
+    else
+        log_info "$shell_rc does not exist, creating it with nvm initialization."
+        echo 'export NVM_DIR="$HOME/.nvm"' > "$shell_rc"
+        echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm' >> "$shell_rc"
+    fi
+}
+
+########################################
+# install mucho and the solana tooling
+########################################
+install_mucho(){
+    npx mucho@latest install
+}
+
+main() {
+    install_nvm_and_node
+
+    ensure_nvm_in_shell
+
+    install_mucho
+
+    echo "Installation complete. Please restart your terminal to apply all changes."
+}
+
+main "$@"


### PR DESCRIPTION
#### Problem

mucho requires the use of node js and npm. if a user does not already have this installed, they will have to search out installing node first on their own, then installing/using mucho. cumbersome.

#### Summary of Changes

add an installer script that can be used as a one liner to install node, nvm, and mucho from a curl command
