### PR TITLE
fix: supress runtime messages

### DIFF
--- a/.changeset/slow-trainers-agree.md
+++ b/.changeset/slow-trainers-agree.md
@@ -1,0 +1,5 @@
+---
+"mucho": patch
+---
+
+suppress runtime warning messages

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,10 @@
 #!/usr/bin/env node
 
-import { assertRuntimeVersion } from "@/lib/node";
+import { assertRuntimeVersion, suppressRuntimeWarnings } from "@/lib/node";
+
+assertRuntimeVersion();
+suppressRuntimeWarnings();
+
 import { checkForSelfUpdate } from "@/lib/npm";
 import { errorOutro } from "@/lib/logs";
 import { cliProgramRoot } from "@/commands";
@@ -16,9 +20,6 @@ import { deployCommand } from "@/commands/deploy";
 import { tokenCommand } from "./commands/token";
 import { docsCommand } from "@/commands/docs";
 import { inspectCommand } from "@/commands/inspect";
-
-// ensure the user running the cli tool is on a supported javascript runtime version
-assertRuntimeVersion();
 
 async function main() {
   // create a global error boundary

--- a/src/lib/node.ts
+++ b/src/lib/node.ts
@@ -46,3 +46,18 @@ export function assertRuntimeVersion() {
     }
   }
 }
+
+/**
+ * Suppress various messages that get logged by NodeJS and other runtimes
+ */
+export function suppressRuntimeWarnings() {
+  const FILTERED_WARNINGS = ["Ed25519", "Warning: WebSockets", "punycode"];
+
+  process.removeAllListeners("warning");
+  process.on("warning", (warning) => {
+    // Only log warnings that shouldn't be suppressed
+    if (!FILTERED_WARNINGS.some((filter) => warning.message.includes(filter))) {
+      console.warn(warning);
+    }
+  });
+}


### PR DESCRIPTION
#### Problem

various javascript runtime messages may appear in the user's console. cluttering the output and sometimes breaking the output.
generally, these can be ignored. so lets ignore them.

#### Summary of Changes

suppress some of the common runtime messages that are safe to be ignored, while leaving the rest on